### PR TITLE
Add simple debug functionality

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -15,7 +15,7 @@
         OsiRegisterer Settings
     </header>
     <nav>
-
+        <div id="debugOptions"></div>
     </nav>
     <main>
         <section id="defaultSection">

--- a/options/options.js
+++ b/options/options.js
@@ -1,3 +1,4 @@
+let debug = false;
 $(function () {
     // Set the current version from the manifest in the footer.
     $("#version").text("OsiRegisterer v" + chrome.runtime.getManifest().version);
@@ -15,13 +16,33 @@ $(function () {
         chrome.storage.sync.set({"defaultResit": $("#defaultResit").prop("checked")});
     });
 
-    $("#defaultStartup").click(function() {
-       chrome.storage.sync.set({"defaultStartup": $("#defaultStartup").prop("checked")});
+    $("#defaultStartup").click(function () {
+        chrome.storage.sync.set({"defaultStartup": $("#defaultStartup").prop("checked")});
     });
 
     chrome.storage.onChanged.addListener(function (changes, areaName) {
         updateFields(changes)
     });
+
+    if (debug) {
+        $("#debugOptions")
+            .append($("<button>")
+                .text("Clear Storage")
+                .click(function () {
+                    chrome.storage.sync.clear();
+                }))
+            .append($("<button>")
+                .text("Clear Courses")
+                .click(function () {
+                    chrome.storage.sync.set({courses: []});
+                }))
+            .append($("<button>")
+                .text("Clear Exams")
+                .click(function () {
+                    chrome.storage.sync.set({exams: []});
+                }));
+
+    }
 });
 
 /**


### PR DESCRIPTION
Fixes #8 

In this commit, an easy way to enable debug functionality is added. This
debug functionality includes buttons to clear the sync, the courses or
the exams respectively. The debug mode is enabled by a boolean in
options.js, which will display these buttons underneath the title in the
options page when true.