### PR TITLE
Add error handling for Osiris errors

### DIFF
--- a/content-scripts/deregister.js
+++ b/content-scripts/deregister.js
@@ -1,6 +1,10 @@
+if (document.getElementsByClassName("OraError").length > 0) {
+    chrome.runtime.sendMessage({phase: "error", message: document.getElementsByClassName("psbError")[0].innerText});
+}
+
 // When there is a confirmation button, click this.
 if (document.getElementById("confirmButton1")) {
-    chrome.runtime.sendMessage({phase: "confirm"}, function() {
+    chrome.runtime.sendMessage({phase: "confirm"}, function () {
         document.getElementById("confirmButton1").click();
     });
 }
@@ -8,11 +12,15 @@ if (document.getElementById("confirmButton1")) {
 // If we can select exams and there is no error, send all exams and click the ones that have to be selected.
 else if (document.getElementsByClassName("OraTableContent").length > 1 && document.getElementsByClassName("OraError").length === 0) {
     var rows = document.getElementsByClassName("OraTableContent")[0].children[0].children;
-    chrome.runtime.sendMessage({"phase": "lookup", "exams": parseExams(rows)}, function(response) {
-        response.indices.forEach(function(index) {
-            rows[index].children[0].children[0].click();
-        });
-        document.getElementsByClassName("psbButtonLink")[0].click();
+    chrome.runtime.sendMessage({"phase": "lookup", "exams": parseExams(rows)}, function (response) {
+        if (response.indices.length > 0) {
+            response.indices.forEach(function (index) {
+                rows[index].children[0].children[0].click();
+            });
+            document.getElementsByClassName("psbButtonLink")[0].click();
+        } else {
+            chrome.runtime.sendMessage({phase: "done"});
+        }
     });
 }
 

--- a/content-scripts/register.js
+++ b/content-scripts/register.js
@@ -1,5 +1,9 @@
-// This means the registration is successfull.
-if (window.location.href.includes("https://osistud.tudelft.nl/osiris_student/InschrijvenToets.do")) {
+if (document.getElementsByClassName("OraError").length > 0) {
+    chrome.runtime.sendMessage({phase: "error", message: document.getElementsByClassName("psbError")[0].innerText});
+}
+
+// This means the registration is successful.
+else if (window.location.href.includes("https://osistud.tudelft.nl/osiris_student/InschrijvenToets.do")) {
     chrome.runtime.sendMessage({phase: "done"});
 }
 
@@ -14,11 +18,16 @@ else if (document.getElementsByClassName("psbInvoerTekst").length > 0) {
 // If there are exams, send them to the background script and select the exams that have to be selected.
 else if (document.getElementsByClassName("OraTableContent").length > 0) {
     var rows = document.getElementsByClassName("OraTableContent")[0].children[0].children;
-    chrome.runtime.sendMessage({phase: "lookup", exams: parseExams(rows)}, function(response) {
-        response.indices.forEach(function(index) {
-            rows[index].children[0].children[0].children[0].click();
-        });
-        document.getElementsByClassName("psbButtonLink")[0].click();
+    chrome.runtime.sendMessage({phase: "lookup", exams: parseExams(rows)}, function (response) {
+        if (response.indices.length > 0) {
+            response.indices.forEach(function (index) {
+                rows[index].children[0].children[0].children[0].click();
+            });
+
+            document.getElementsByClassName("psbButtonLink")[0].click();
+        } else {
+            chrome.runtime.sendMessage({phase: "done"});
+        }
     });
 }
 


### PR DESCRIPTION
In this commit, basic error handling for errors posted by Osiris is
applied. This means that every time that Osiris throws an error, a popup
is created with the error message, stating that this has to be reported.

Three cases of errors commonly occurring are removed:
- Registering for an exam for which you are already registered (by
changing the updating sequence).
- Selecting nothing for (de)registering (by checking this in the content
scripts)